### PR TITLE
Upgrade logback-steno version and simplify verticle launch logging.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,8 +130,8 @@
     <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
     <jodatime.version>2.1</jodatime.version>
     <junit.version>4.11</junit.version>
-    <logback.version>1.0.13</logback.version>
-    <logback-steno.version>1.9.3</logback-steno.version>
+    <logback.version>1.1.7</logback.version>
+    <logback-steno.version>1.16.1</logback-steno.version>
     <mockito.version>1.9.5</mockito.version>
     <powermock.version>1.5.4</powermock.version>
     <slf4j.version>1.7.12</slf4j.version>

--- a/src/main/java/com/groupon/vertx/utils/MainVerticle.java
+++ b/src/main/java/com/groupon/vertx/utils/MainVerticle.java
@@ -56,7 +56,7 @@ public class MainVerticle extends AbstractVerticle {
                     startedResult.complete(null);
                 } else {
                     if (abortOnFailure) {
-                        log.error("start", "abort", "Shutting down due to one or more errors", result.cause());
+                        log.warn("start", "abort", new String[]{"message"}, "Shutting down due to one or more errors");
                         vertx.close();
                     } else {
                         startedResult.fail(result.cause());

--- a/src/main/java/com/groupon/vertx/utils/deployment/VerticleDeployment.java
+++ b/src/main/java/com/groupon/vertx/utils/deployment/VerticleDeployment.java
@@ -57,12 +57,12 @@ public class VerticleDeployment implements Deployment {
             @Override
             public void handle(AsyncResult<String> deployResult) {
                 if (deployResult.succeeded() && !deployResult.result().isEmpty()) {
+                    log.debug("deploy", "success", new String[]{"message"}, String.format("Deployed verticle %s successfully", name));
                     deployId.complete(deployResult.result());
-                    log.info("deploy", "success", new String[]{"id", "instances", "name", "class"}, deployResult.result(), instances, name, className);
                 } else {
-                    String reason = String.format("Failed to deploy verticle %s", name);
-                    log.error("deploy", "failure", reason, new String[]{"instances", "name", "class"}, instances, name, className, deployResult.cause());
-                    deployId.fail(new Exception(reason));
+                    String message = String.format("Failed to deploy verticle %s", name);
+                    log.debug("deploy", "failure", new String[]{"message"}, message);
+                    deployId.fail(new Exception(message, deployResult.cause()));
                 }
             }
         });
@@ -78,8 +78,8 @@ public class VerticleDeployment implements Deployment {
 
     @Override
     public void abort(Throwable cause) {
-        String reason = String.format("Aborted deploying verticle %s", name);
-        log.error("abort", "error", reason, cause);
-        deployId.fail(new Exception(reason, cause));
+        String message = String.format("Aborted deploying verticle %s", name);
+        log.debug("abort", "failure", new String[]{"message"}, message);
+        deployId.fail(new Exception(message, cause));
     }
 }


### PR DESCRIPTION
The current logging drops important information out of the result chain and logs multiple error messages many of which are unimportant. This leads to more time spent finding the actual cause of verticle deployment failure and requires a deeper than desirable knowledge of the deployment code to find the useful information. 

This pull request pushes all exceptions to the DeploymentMonitorHandler where they are all logged (if any). Some of the error messages along the way have been removed, in my opinion either rethrow (or in async pass on the cause) or log, but not both. In some cases debug log messages are emitted instead where additional information may aid with debugging the launcher itself.

I'm open to changing any of the messaging, levels, etc.. -- there are some parts that I did not have ideal answers for, so please let me know what works for you as well.

Below are snapshots of output for the same failure using 3.2.0 and 3.2.1-SNAPSHOT (this PR) for comparison. They used the KeyValueEncoder from Logback-Steno but the output would be reasonably similar under the StenoEncoder.

Old Logging:

```
2016-10-19 21:08:37,933 vert.x-eventloop-thread-0 [INFO] com.groupon.vertx.utils.deployment.VerticleDeployment : name="start", eventSource="verticleDeployment", method="deploy", instances="1", name="Session-TableManager", class="com.qualtrics.dynamodb.timeseries.TableManagerVerticle" 
2016-10-19 21:08:37,934 vert.x-eventloop-thread-2 [INFO] com.qualtrics.dynamodb.timeseries.TableManagerVerticle : name="start", message="tableManagerVerticle" 
2016-10-19 21:08:37,940 vert.x-eventloop-thread-2 [INFO] com.qualtrics.dynamodb.timeseries.TableManagerVerticle : name="log", message="Computed update tables interval.", updateTablesInterval="PT2898.178S" 
2016-10-19 21:08:39,947 vert.x-eventloop-thread-0 [ERROR] com.groupon.vertx.utils.deployment.VerticleDeployment : name="failure", eventSource="verticleDeployment", method="deploy", reason="Failed to deploy verticle Session-TableManager", instances="1", name="Session-TableManager", class="com.qualtrics.dynamodb.timeseries.TableManagerVerticle" com.amazonaws.AmazonClientException: Unable to load AWS credentials from any provider in the chain
    at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:131)
    at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.invoke(DynamoDbAsyncClient.java:527)
    at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.listTablesAsync(DynamoDbAsyncClient.java:353)
    at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.listTablesAsync(DynamoDbAsyncClient.java:358)
    at com.qualtrics.dynamodb.timeseries.TableManagerVerticle.startUnsafe(TableManagerVerticle.java:118)
    at com.qualtrics.dynamodb.timeseries.TableManagerVerticle.start(TableManagerVerticle.java:76)
    at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$8(DeploymentManager.java:434)
    at io.vertx.core.impl.ContextImpl.lambda$wrapTask$3(ContextImpl.java:359)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:339)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:393)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:742)
    at java.lang.Thread.run(Thread.java:745)

2016-10-19 21:08:39,948 vert.x-eventloop-thread-0 [INFO] com.groupon.vertx.utils.deployment.MultiVerticleDeployment : name="deployNextVerticle", eventSource="multiVerticleDeployment", method="deploy" 
2016-10-19 21:08:39,948 vert.x-eventloop-thread-0 [ERROR] com.groupon.vertx.utils.deployment.DeploymentMonitorHandler : name="error", eventSource="verticleDeployHandler", method="handle", reason="Caught exception; failed to deploy verticle" java.lang.Exception: Failed to deploy verticle Session-TableManager
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:65)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:56)
    at io.vertx.core.impl.DeploymentManager.lambda$reportResult$6(DeploymentManager.java:396)
    at io.vertx.core.impl.ContextImpl.lambda$wrapTask$3(ContextImpl.java:359)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:339)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:393)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:742)
    at java.lang.Thread.run(Thread.java:745)
2016-10-19 21:08:40,502 vert.x-eventloop-thread-0 [ERROR] com.groupon.vertx.utils.deployment.DeploymentMonitorHandler : name="error", eventSource="verticleDeployHandler", method="handleCompletion", reason="Failed to deploy 2 of 3 verticle(s)" 
2016-10-19 21:08:40,502 vert.x-eventloop-thread-0 [ERROR] com.groupon.vertx.utils.deployment.MultiVerticleDeployment : name="failure", eventSource="multiVerticleDeployment", method="deploy", reason="Failed to deploy verticle: Failed to deploy 2 of 3 verticle(s)" java.lang.Exception: Failed to deploy 2 of 3 verticle(s)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.handleCompletion(DeploymentMonitorHandler.java:85)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.checkForCompletion(DeploymentMonitorHandler.java:74)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.handle(DeploymentMonitorHandler.java:59)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$2.handle(MultiVerticleDeployment.java:108)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$2.handle(MultiVerticleDeployment.java:100)
    at io.vertx.core.impl.FutureImpl.checkCallHandler(FutureImpl.java:158)
    at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:111)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:60)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:56)
    at io.vertx.core.impl.DeploymentManager.lambda$reportResult$6(DeploymentManager.java:396)
    at io.vertx.core.impl.ContextImpl.lambda$wrapTask$3(ContextImpl.java:359)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:339)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:393)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:742)
    at java.lang.Thread.run(Thread.java:745)

2016-10-19 21:08:40,503 vert.x-eventloop-thread-0 [ERROR] com.groupon.vertx.utils.MainVerticle : name="abort", eventSource="mainVerticle", method="start", reason="Shutting down due to one or more errors" java.lang.Exception: Failed to deploy verticle: Failed to deploy 2 of 3 verticle(s)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$1.handle(MultiVerticleDeployment.java:93)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$1.handle(MultiVerticleDeployment.java:84)
    at io.vertx.core.impl.FutureImpl.checkCallHandler(FutureImpl.java:158)
    at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:148)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.handleCompletion(DeploymentMonitorHandler.java:85)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.checkForCompletion(DeploymentMonitorHandler.java:74)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.handle(DeploymentMonitorHandler.java:59)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$2.handle(MultiVerticleDeployment.java:108)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$2.handle(MultiVerticleDeployment.java:100)
    at io.vertx.core.impl.FutureImpl.checkCallHandler(FutureImpl.java:158)
    at io.vertx.core.impl.FutureImpl.complete(FutureImpl.java:111)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:60)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:56)
    at io.vertx.core.impl.DeploymentManager.lambda$reportResult$6(DeploymentManager.java:396)
    at io.vertx.core.impl.ContextImpl.lambda$wrapTask$3(ContextImpl.java:359)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:339)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:393)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:742)
    at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.Exception: Failed to deploy 2 of 3 verticle(s)
    ... 15 common frames omitted

2016-10-19 21:08:40,504 vert.x-eventloop-thread-0 [INFO] com.groupon.vertx.utils.deployment.VerticleDeployment : name="success", eventSource="verticleDeployment", method="deploy", id="1da1e311-e985-40a1-b9b0-eda8124a80ee", instances="8", name="HttpServerVerticle", class="com.qualtrics.core.common.http.HttpServerVerticle" 
```

You can see how far up the actual useful error is and how many useless stack traces are output after it (developer sees error + stack trace they expect to find something useful).

New Logging:

```
2016-10-19 21:04:55,920 vert.x-eventloop-thread-0 [INFO] com.groupon.vertx.utils.deployment.VerticleDeployment : name="start", eventSource="verticleDeployment", method="deploy", instances="1", name="Login-TableManager", class="com.qualtrics.dynamodb.timeseries.TableManagerVerticle" 
2016-10-19 21:04:55,920 vert.x-eventloop-thread-2 [INFO] com.qualtrics.dynamodb.timeseries.TableManagerVerticle : name="start", message="tableManagerVerticle" 
2016-10-19 21:04:55,922 vert.x-eventloop-thread-2 [INFO] com.qualtrics.dynamodb.timeseries.TableManagerVerticle : name="log", message="Computed update tables interval.", updateTablesInterval="PT2898.178S" 
2016-10-19 21:04:57,929 vert.x-eventloop-thread-0 [DEBUG] com.groupon.vertx.utils.deployment.VerticleDeployment : name="failure", eventSource="verticleDeployment", method="deploy", message="Failed to deploy verticle Login-TableManager" 
2016-10-19 21:04:57,932 vert.x-eventloop-thread-0 [ERROR] com.groupon.vertx.utils.deployment.DeploymentMonitorHandler : name="error", eventSource="verticleDeployHandler", method="handleCompletion", reason="Failed to deploy 2 of 3 verticle(s)" java.lang.Exception: Failed to deploy 2 of 3 verticle(s)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.handleCompletion(DeploymentMonitorHandler.java:84)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.checkForCompletion(DeploymentMonitorHandler.java:73)
    at com.groupon.vertx.utils.deployment.DeploymentMonitorHandler.handle(DeploymentMonitorHandler.java:60)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$2.handle(MultiVerticleDeployment.java:107)
    at com.groupon.vertx.utils.deployment.MultiVerticleDeployment$2.handle(MultiVerticleDeployment.java:98)
    at io.vertx.core.impl.FutureImpl.checkCallHandler(FutureImpl.java:158)
    at io.vertx.core.impl.FutureImpl.fail(FutureImpl.java:148)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:65)
    at com.groupon.vertx.utils.deployment.VerticleDeployment$1.handle(VerticleDeployment.java:56)
    at io.vertx.core.impl.DeploymentManager.lambda$reportResult$6(DeploymentManager.java:396)
    at io.vertx.core.impl.ContextImpl.lambda$wrapTask$3(ContextImpl.java:359)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:339)
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:393)
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:742)
    at java.lang.Thread.run(Thread.java:745)
    Suppressed: java.lang.Exception: Failed to deploy verticle Session-TableManager
        ... 8 common frames omitted
    Caused by: com.amazonaws.AmazonClientException: Unable to load AWS credentials from any provider in the chain
        at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:131)
        at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.invoke(DynamoDbAsyncClient.java:527)
        at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.listTablesAsync(DynamoDbAsyncClient.java:353)
        at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.listTablesAsync(DynamoDbAsyncClient.java:358)
        at com.qualtrics.dynamodb.timeseries.TableManagerVerticle.startUnsafe(TableManagerVerticle.java:118)
        at com.qualtrics.dynamodb.timeseries.TableManagerVerticle.start(TableManagerVerticle.java:76)
        at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$8(DeploymentManager.java:434)
        ... 5 common frames omitted
    Suppressed: java.lang.Exception: Failed to deploy verticle Login-TableManager
        ... 8 common frames omitted
    Caused by: com.amazonaws.AmazonClientException: Unable to load AWS credentials from any provider in the chain
        at com.amazonaws.auth.AWSCredentialsProviderChain.getCredentials(AWSCredentialsProviderChain.java:131)
        at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.invoke(DynamoDbAsyncClient.java:527)
        at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.listTablesAsync(DynamoDbAsyncClient.java:353)
        at com.qualtrics.vertx.dynamodb.DynamoDbAsyncClient.listTablesAsync(DynamoDbAsyncClient.java:358)
        at com.qualtrics.dynamodb.timeseries.TableManagerVerticle.startUnsafe(TableManagerVerticle.java:118)
        at com.qualtrics.dynamodb.timeseries.TableManagerVerticle.start(TableManagerVerticle.java:76)
        at io.vertx.core.impl.DeploymentManager.lambda$doDeploy$8(DeploymentManager.java:434)
        ... 5 common frames omitted

2016-10-19 21:04:57,933 vert.x-eventloop-thread-0 [WARN] com.groupon.vertx.utils.MainVerticle : name="abort", eventSource="mainVerticle", method="start", message="Shutting down due to one or more errors" 
```

Under the new logging code there is a single error message with all the necessary exceptions in one place and it's the second last line of output before the program exits.

Thanks!
Ville
