### PR TITLE
Update content type for healthcheck handler

### DIFF
--- a/src/main/java/com/groupon/vertx/utils/HealthcheckHandler.java
+++ b/src/main/java/com/groupon/vertx/utils/HealthcheckHandler.java
@@ -32,7 +32,7 @@ import io.vertx.core.http.HttpServerRequest;
 @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
 public abstract class HealthcheckHandler implements Handler<HttpServerRequest> {
     private static final Logger LOG = Logger.getLogger(HealthcheckHandler.class);
-    private static final String CONTENT_TYPE = "plain/text";
+    private static final String CONTENT_TYPE = "text/plain";
     private static final String CACHE_CONTROL = "private, no-cache, no-store, must-revalidate";
 
     public abstract void handle(final HttpServerRequest request);

--- a/src/test/java/com/groupon/vertx/utils/HealthcheckHandlerTest.java
+++ b/src/test/java/com/groupon/vertx/utils/HealthcheckHandlerTest.java
@@ -44,7 +44,7 @@ import org.mockito.MockitoAnnotations;
 public class HealthcheckHandlerTest {
     private static final HttpResponseStatus OK = HttpResponseStatus.OK;
     private static final HttpResponseStatus SERVICE_UNAVAILABLE = HttpResponseStatus.SERVICE_UNAVAILABLE;
-    private static final String CONTENT_TYPE = "plain/text";
+    private static final String CONTENT_TYPE = "text/plain";
     private static final String CACHE_CONTROL = "private, no-cache, no-store, must-revalidate";
 
     @Mock


### PR DESCRIPTION
Currently this is set to 'plain/text' which is not a valid content type. This change updates the content type to be 'text/plain', which is a valid content type.