### PR TITLE
Upgrade Dependency Versions and Migrate to Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- oraclejdk11
 cache:
   directories:
   - "$HOME/.m2"

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,10 @@
   </scm>
 
   <properties>
+
     <!--Vertx dependency versions-->
-    <netty.version>4.1.30.Final</netty.version>
-    <vertx.version>3.6.3</vertx.version>
+    <netty.version>4.1.49.Final</netty.version>
+    <vertx.version>3.9.4</vertx.version>
 
     <!--Other dependency versions-->
     <findbugs.annotations.version>3.0.1</findbugs.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,10 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>com.groupon.api</groupId>
     <artifactId>api-parent-pom</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <relativePath />
   </parent>
 
@@ -101,6 +101,7 @@
     <mockito.version>2.23.0</mockito.version>
     <powermock.version>1.6.6</powermock.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <maven.dependency.analyzer.version>1.11.1</maven.dependency.analyzer.version>
 
     <!--Coverage Settings-->
     <jacoco.check.line.coverage>0.5</jacoco.check.line.coverage>
@@ -219,7 +220,7 @@
           <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-analyzer</artifactId>
-            <version>1.11.1</version>
+            <version>${maven.dependency.analyzer.version}</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
 
   <properties>
 
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+
     <!--Vertx dependency versions-->
     <netty.version>4.1.49.Final</netty.version>
     <vertx.version>3.9.4</vertx.version>
@@ -212,6 +215,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-analyzer</artifactId>
+            <version>1.11.1</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>analyze</id>

--- a/src/main/java/com/groupon/vertx/http/HttpServerRequestWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerRequestWrapper.java
@@ -126,7 +126,7 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     }
 
     @Override
-    public X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
+    public @Deprecated X509Certificate[] peerCertificateChain() throws SSLPeerUnverifiedException {
         return serverRequest.peerCertificateChain();
     }
 

--- a/src/main/java/com/groupon/vertx/http/HttpServerRequestWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerRequestWrapper.java
@@ -15,14 +15,18 @@
  */
 package com.groupon.vertx.http;
 
+import java.util.Map;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.security.cert.X509Certificate;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.Cookie;
 import io.vertx.core.http.HttpConnection;
 import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.HttpMethod;
@@ -138,8 +142,14 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     }
 
     @Override
+    @Deprecated
     public NetSocket netSocket() {
         return serverRequest.netSocket();
+    }
+
+    @Override
+    public void toNetSocket(Handler<AsyncResult<NetSocket>> handler) {
+        serverRequest.toNetSocket(handler);
     }
 
     @Override
@@ -231,8 +241,14 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     }
 
     @Override
+    @Deprecated
     public ServerWebSocket upgrade() {
         return serverRequest.upgrade();
+    }
+
+    @Override
+    public void toWebSocket(Handler<AsyncResult<ServerWebSocket>> handler) {
+        serverRequest.toWebSocket(handler);
     }
 
     @Override
@@ -259,6 +275,21 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     public HttpServerRequest streamPriorityHandler(Handler<StreamPriority> handler) {
         serverRequest.streamPriorityHandler(handler);
         return this;
+    }
+
+    @Override
+    public @Nullable Cookie getCookie(String s) {
+        return serverRequest.getCookie(s);
+    }
+
+    @Override
+    public int cookieCount() {
+        return serverRequest.cookieCount();
+    }
+
+    @Override
+    public Map<String, Cookie> cookieMap() {
+        return serverRequest.cookieMap();
     }
 
     @Override

--- a/src/main/java/com/groupon/vertx/http/HttpServerRequestWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerRequestWrapper.java
@@ -216,18 +216,18 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     }
 
     @Override
-    public String getHeader(String s) {
-        return serverRequest.getHeader(s);
+    public String getHeader(String headerName) {
+        return serverRequest.getHeader(headerName);
     }
 
     @Override
-    public String getHeader(CharSequence charSequence) {
-        return serverRequest.getHeader(charSequence);
+    public String getHeader(CharSequence headerName) {
+        return serverRequest.getHeader(headerName);
     }
 
     @Override
-    public String getParam(String s) {
-        return serverRequest.getParam(s);
+    public String getParam(String paramName) {
+        return serverRequest.getParam(paramName);
     }
 
     @Override
@@ -236,8 +236,8 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     }
 
     @Override
-    public String getFormAttribute(String s) {
-        return serverRequest.getFormAttribute(s);
+    public String getFormAttribute(String attributeName) {
+        return serverRequest.getFormAttribute(attributeName);
     }
 
     @Override
@@ -278,8 +278,8 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     }
 
     @Override
-    public @Nullable Cookie getCookie(String s) {
-        return serverRequest.getCookie(s);
+    public @Nullable Cookie getCookie(String name) {
+        return serverRequest.getCookie(name);
     }
 
     @Override

--- a/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
@@ -233,8 +233,8 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void end(String s, Handler<AsyncResult<Void>> handler) {
-        serverResponse.end(s, handler);
+    public void end(String chunk, Handler<AsyncResult<Void>> handler) {
+        serverResponse.end(chunk, handler);
     }
 
     @Override
@@ -243,8 +243,8 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public void end(String s, String s1, Handler<AsyncResult<Void>> handler) {
-        serverResponse.end(s, s1, handler);
+    public void end(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
+        serverResponse.end(chunk, enc, handler);
     }
 
     @Override

--- a/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
@@ -153,8 +153,8 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public HttpServerResponse write(String s, String s1, Handler<AsyncResult<Void>> handler) {
-        serverResponse.write(s, s1, handler);
+    public HttpServerResponse write(String chunk, String enc, Handler<AsyncResult<Void>> handler) {
+        serverResponse.write(chunk, enc, handler);
         return this;
     }
 
@@ -165,8 +165,8 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public HttpServerResponse write(String s, Handler<AsyncResult<Void>> handler) {
-        serverResponse.write(s, handler);
+    public HttpServerResponse write(String chunk, Handler<AsyncResult<Void>> handler) {
+        serverResponse.write(chunk, handler);
         return this;
     }
 
@@ -183,14 +183,14 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public HttpServerResponse sendFile(String s, long l, long l1) {
-        serverResponse.sendFile(s, l, l1);
+    public HttpServerResponse sendFile(String filename, long offset, long length) {
+        serverResponse.sendFile(filename, offset, length);
         return this;
     }
 
     @Override
-    public HttpServerResponse sendFile(String s, long l, long l1, Handler<AsyncResult<Void>> handler) {
-        serverResponse.sendFile(s, l, l1);
+    public HttpServerResponse sendFile(String filename, long offset, long length, Handler<AsyncResult<Void>> handler) {
+        serverResponse.sendFile(filename, offset, length, handler);
         return this;
     }
 
@@ -370,8 +370,8 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
-    public @Nullable Cookie removeCookie(String s, boolean b) {
-        return serverResponse.removeCookie(s, b);
+    public @Nullable Cookie removeCookie(String name, boolean invalidate) {
+        return serverResponse.removeCookie(name, invalidate);
     }
 
     @Override

--- a/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
@@ -360,7 +360,7 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
 
     @Override
     public HttpServerResponse addCookie(Cookie cookie) {
-        addCookie(cookie);
+        serverResponse.addCookie(cookie);
         return this;
     }
 

--- a/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
+++ b/src/main/java/com/groupon/vertx/http/HttpServerResponseWrapper.java
@@ -21,8 +21,11 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.Cookie;
+import io.vertx.core.http.HttpFrame;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.StreamPriority;
 
 /**
  * Base class for wrapping a Vert.x HttpServerResponse so method can be intercepted.
@@ -138,14 +141,32 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    public HttpServerResponse write(Buffer buffer, Handler<AsyncResult<Void>> handler) {
+        serverResponse.write(buffer, handler);
+        return this;
+    }
+
+    @Override
     public HttpServerResponse write(String chunk, String enc) {
         serverResponse.write(chunk, enc);
         return this;
     }
 
     @Override
+    public HttpServerResponse write(String s, String s1, Handler<AsyncResult<Void>> handler) {
+        serverResponse.write(s, s1, handler);
+        return this;
+    }
+
+    @Override
     public HttpServerResponse write(String chunk) {
         serverResponse.write(chunk);
+        return this;
+    }
+
+    @Override
+    public HttpServerResponse write(String s, Handler<AsyncResult<Void>> handler) {
+        serverResponse.write(s, handler);
         return this;
     }
 
@@ -212,8 +233,18 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    public void end(String s, Handler<AsyncResult<Void>> handler) {
+        serverResponse.end(s, handler);
+    }
+
+    @Override
     public void end(String chunk, String enc) {
         serverResponse.end(chunk, enc);
+    }
+
+    @Override
+    public void end(String s, String s1, Handler<AsyncResult<Void>> handler) {
+        serverResponse.end(s, s1, handler);
     }
 
     @Override
@@ -222,8 +253,18 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    public void end(Buffer buffer, Handler<AsyncResult<Void>> handler) {
+        serverResponse.end(buffer, handler);
+    }
+
+    @Override
     public void end() {
         serverResponse.end();
+    }
+
+    @Override
+    public void end(Handler<AsyncResult<Void>> handler) {
+        serverResponse.end(handler);
     }
 
     @Override
@@ -291,6 +332,11 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     }
 
     @Override
+    public void reset() {
+        serverResponse.reset();
+    }
+
+    @Override
     public void reset(final long code) {
         serverResponse.reset(code);
     }
@@ -298,6 +344,34 @@ public class HttpServerResponseWrapper implements HttpServerResponse {
     @Override
     public HttpServerResponse writeCustomFrame(final int type, final int flags, final Buffer payload) {
         return serverResponse.writeCustomFrame(type, flags, payload);
+    }
+
+    @Override
+    public HttpServerResponse writeCustomFrame(HttpFrame frame) {
+        serverResponse.writeCustomFrame(frame);
+        return this;
+    }
+
+    @Override
+    public HttpServerResponse setStreamPriority(StreamPriority streamPriority) {
+        serverResponse.setStreamPriority(streamPriority);
+        return this;
+    }
+
+    @Override
+    public HttpServerResponse addCookie(Cookie cookie) {
+        addCookie(cookie);
+        return this;
+    }
+
+    @Override
+    public @Nullable Cookie removeCookie(String name) {
+        return serverResponse.removeCookie(name);
+    }
+
+    @Override
+    public @Nullable Cookie removeCookie(String s, boolean b) {
+        return serverResponse.removeCookie(s, b);
     }
 
     @Override

--- a/src/main/java/com/groupon/vertx/utils/AsyncRescheduleHandler.java
+++ b/src/main/java/com/groupon/vertx/utils/AsyncRescheduleHandler.java
@@ -3,6 +3,7 @@ package com.groupon.vertx.utils;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 
 /**
@@ -15,10 +16,10 @@ public class AsyncRescheduleHandler implements Handler<Long> {
 
     private static final Logger log = Logger.getLogger(RescheduleHandler.class, "rescheduleHandler");
     private final Vertx vertx;
-    private final Handler<Future<Void>> handler;
+    private final Handler<Promise<Void>> handler;
     private final int interval;
 
-    public AsyncRescheduleHandler(Vertx vertx, Handler<Future<Void>> handler, int interval) {
+    public AsyncRescheduleHandler(Vertx vertx, Handler<Promise<Void>> handler, int interval) {
         if (vertx == null) {
             throw new IllegalArgumentException("Vertx cannot be null");
         }
@@ -37,8 +38,9 @@ public class AsyncRescheduleHandler implements Handler<Long> {
         log.debug("handle", "started");
         final Handler<Long> that = this;
 
-        Future<Void> handlerFuture = Future.future();
-        handlerFuture.setHandler(new Handler<AsyncResult<Void>>() {
+        Promise<Void> handlerPromise = Promise.promise();
+        Future<Void> handlerFuture = handlerPromise.future();
+        handlerFuture.onComplete(new Handler<AsyncResult<Void>>() {
             @Override
             public void handle(AsyncResult<Void> futureResult) {
                 if (futureResult.failed()) {
@@ -50,6 +52,6 @@ public class AsyncRescheduleHandler implements Handler<Long> {
             }
         });
 
-        handler.handle(handlerFuture);
+        handler.handle(handlerPromise);
     }
 }

--- a/src/main/java/com/groupon/vertx/utils/MainVerticle.java
+++ b/src/main/java/com/groupon/vertx/utils/MainVerticle.java
@@ -19,6 +19,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.MessageCodec;
 import io.vertx.core.json.JsonArray;
@@ -48,7 +49,7 @@ public class MainVerticle extends AbstractVerticle {
      * @param startedResult future indicating when all verticles have been deployed successfully
      */
     @Override
-    public void start(final Future<Void> startedResult) {
+    public void start(final Promise<Void> startedResult) {
         final JsonObject config = config();
         final boolean abortOnFailure = config.getBoolean(ABORT_ON_FAILURE_FIELD, true);
 
@@ -61,7 +62,7 @@ public class MainVerticle extends AbstractVerticle {
         }
 
         Future<Void> deployResult = deployVerticles(config);
-        deployResult.setHandler(result -> {
+        deployResult.onComplete(result -> {
             if (result.succeeded()) {
                 startedResult.complete(null);
             } else {

--- a/src/main/java/com/groupon/vertx/utils/deployment/MultiVerticleDeployment.java
+++ b/src/main/java/com/groupon/vertx/utils/deployment/MultiVerticleDeployment.java
@@ -21,6 +21,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -69,13 +70,14 @@ public class MultiVerticleDeployment {
 
         started = true;
 
-        final Future<Void> deploymentResult = Future.future();
+        final Promise<Void> deploymentPromise = Promise.promise();
+        final Future<Void> deploymentResult = deploymentPromise.future();
         final Config deployConfig;
 
         try {
             deployConfig = new Config(config);
         } catch (Exception e) {
-            deploymentResult.fail(e);
+            deploymentPromise.fail(e);
             return deploymentResult;
         }
 
@@ -86,9 +88,9 @@ public class MultiVerticleDeployment {
             @Override
             public void handle(AsyncResult<Void> result) {
                 if (result.succeeded()) {
-                    deploymentResult.complete(null);
+                    deploymentPromise.complete(null);
                 } else {
-                    deploymentResult.fail(result.cause());
+                    deploymentPromise.fail(result.cause());
                 }
             }
         });

--- a/src/main/java/com/groupon/vertx/utils/deployment/VerticleDeployment.java
+++ b/src/main/java/com/groupon/vertx/utils/deployment/VerticleDeployment.java
@@ -17,8 +17,8 @@ package com.groupon.vertx.utils.deployment;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -37,7 +37,7 @@ public class VerticleDeployment implements Deployment {
     protected final Vertx vertx;
     protected final String name;
     protected final String className;
-    protected final Future<String> deployId;
+    protected final Promise<String> deployId;
 
 
     public VerticleDeployment(Vertx vertx, String name, String className, Handler<AsyncResult<String>> finishedHandler) {
@@ -45,8 +45,8 @@ public class VerticleDeployment implements Deployment {
         this.name = name;
         this.className = className;
 
-        deployId = Future.future();
-        deployId.setHandler(finishedHandler);
+        deployId = Promise.promise();
+        deployId.future().onComplete(finishedHandler);
     }
 
     @Override

--- a/src/test/java/com/groupon/vertx/utils/MainVerticleTest.java
+++ b/src/test/java/com/groupon/vertx/utils/MainVerticleTest.java
@@ -30,8 +30,8 @@ import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
@@ -66,8 +66,8 @@ public class MainVerticleTest {
     private MainVerticle verticle;
     private CountDownLatch latch;
     private JsonObject config;
-    private Future<Void> deployResult = Future.future();
-    private Future<Void> startedResult = Future.future();
+    private Promise<Void> deployResult = Promise.promise();
+    private Promise<Void> startedResult = Promise.promise();
 
     @Captor
     private ArgumentCaptor<Handler<AsyncResult<String>>> handlerCaptor;
@@ -96,7 +96,7 @@ public class MainVerticleTest {
 
     @Test
     public void testSuccess() {
-        startedResult.setHandler(result -> {
+        startedResult.future().onComplete(result -> {
             assertTrue(result.succeeded());
             latch.countDown();
         });
@@ -117,7 +117,7 @@ public class MainVerticleTest {
     public void testFailureWithoutShutdown() {
         config.put("abortOnFailure", false);
 
-        startedResult.setHandler(result -> {
+        startedResult.future().onComplete(result -> {
             assertTrue(result.failed());
             verify(vertx, never()).close();
             latch.countDown();
@@ -140,7 +140,7 @@ public class MainVerticleTest {
         config.put("abortOnFailure", false);
         config.put("messageCodecs", new JsonArray("[\"com.groupon.vertx.utils.MainVerticleTest$NonExistentCodec\"]"));
 
-        startedResult.setHandler(result -> {
+        startedResult.future().onComplete(result -> {
             assertFalse(result.failed());
             verify(vertx, never()).close();
             latch.countDown();

--- a/src/test/java/com/groupon/vertx/utils/deployment/MultiVerticleDeploymentTest.java
+++ b/src/test/java/com/groupon/vertx/utils/deployment/MultiVerticleDeploymentTest.java
@@ -144,7 +144,7 @@ public class MultiVerticleDeploymentTest {
 
     @Test
     public void testSuccess() {
-        multiVerticleDeployment.deploy(config).setHandler(result -> {
+        multiVerticleDeployment.deploy(config).onComplete(result -> {
             assertTrue(result.succeeded(), "Deployment should succeed");
             latch.countDown();
         });
@@ -154,7 +154,7 @@ public class MultiVerticleDeploymentTest {
     public void testBadConfig() {
         config.remove("verticles");
 
-        multiVerticleDeployment.deploy(config).setHandler(result -> {
+        multiVerticleDeployment.deploy(config).onComplete(result -> {
             assertTrue(result.failed(), "Deployment should fail");
             latch.countDown();
         });
@@ -165,7 +165,7 @@ public class MultiVerticleDeploymentTest {
     public void testDeployFailure() {
         stubDeploymentDeployWithResult(Future.<String>failedFuture(new Exception("failure")));
 
-        multiVerticleDeployment.deploy(config).setHandler(result -> {
+        multiVerticleDeployment.deploy(config).onComplete(result -> {
             assertTrue(result.failed(), "Deployment should fail");
             latch.countDown();
         });
@@ -176,7 +176,7 @@ public class MultiVerticleDeploymentTest {
     public void testBadVerticleConfigA() {
         config.getJsonObject("verticles").getJsonObject(VERTICLE_NAME_A).remove("instances");
 
-        multiVerticleDeployment.deploy(config).setHandler(result -> {
+        multiVerticleDeployment.deploy(config).onComplete(result -> {
             assertTrue(result.failed(), "Deployment should fail");
             latch.countDown();
         });
@@ -186,7 +186,7 @@ public class MultiVerticleDeploymentTest {
     public void testBadVerticleConfigB() {
         config.getJsonObject("verticles").getJsonObject(VERTICLE_NAME_A).remove("class");
 
-        multiVerticleDeployment.deploy(config).setHandler(result -> {
+        multiVerticleDeployment.deploy(config).onComplete(result -> {
             assertTrue(result.failed(), "Deployment should fail");
             latch.countDown();
         });


### PR DESCRIPTION
# Related JIRA Ticket

https://jira.groupondev.com/browse/GAPI-16614

# Motivation and Context

Vertx-utils is a dependency of Lazlo so it is being moved to Java 11 as part of the Lazlo migration to Java 11. It also shares the dependencies vertx and netty with Lazlo. Those dependencies were upgraded in Lazlo so they are also being upgraded here to match the Lazlo versions.

# Changes

* Upgrade Vertx to 3.9.3
* Upgrade Netty to 4.1.49
* Add maven-dependency-analyzer to fix an issue with maven-dependency-analyzer in JDK 11.
* Annotate deprecated wrapped methods from HttpServerResponse and HttpServerRequest.
    * Vertx still uses the javax X509Certificate which is deprecated. Could potentially convert it to the java version in the wrapping method.
* Fixed Vertx Future deprecations.
